### PR TITLE
AbstractCollectionAction adjustments for repeaters + fix bug RemoveComponentsFromWorkspacesFrontAction : sub modules

### DIFF
--- a/application/src/main/java/org/jspresso/framework/application/backend/action/AbstractCollectionAction.java
+++ b/application/src/main/java/org/jspresso/framework/application/backend/action/AbstractCollectionAction.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.jspresso.framework.binding.ICollectionConnector;
 import org.jspresso.framework.binding.IValueConnector;
 import org.jspresso.framework.model.descriptor.ICollectionDescriptorProvider;
+import org.jspresso.framework.model.descriptor.IModelDescriptor;
 
 /**
  * Base class for backend actions acting on collection models. This class is
@@ -56,9 +57,12 @@ public abstract class AbstractCollectionAction extends BackendAction {
    * {@inheritDoc}
    */
   @Override
-  protected ICollectionDescriptorProvider<?> getModelDescriptor(
-      Map<String, Object> context) {
-    return (ICollectionDescriptorProvider<?>) super.getModelDescriptor(context);
+  protected ICollectionDescriptorProvider<?> getModelDescriptor(Map<String, Object> context) {
+    IModelDescriptor modelDescriptor = super.getModelDescriptor(context);
+    if (modelDescriptor instanceof ICollectionDescriptorProvider<?>) {
+      return (ICollectionDescriptorProvider<?>) modelDescriptor;
+    }
+    return (ICollectionDescriptorProvider<?>) getModelConnector(context).getModelDescriptor();
   }
 
   /**


### PR DESCRIPTION
Please review carefully !

NB : You can test the `Remove` and `Duplicate` action into HRSample. See screenshot :
![pastedgraphic-19](https://cloud.githubusercontent.com/assets/4968224/15612530/731da908-242f-11e6-95db-dfcea07a1b65.png)

You can test the workspace clean up fix by adding Teams as modules inside workspace "Employees / Teams" (See screenshot bellow) and then removing them using the `Remove` action from workspace "Organization / Companies" (see the above screenshot again)
![pastedgraphic-18](https://cloud.githubusercontent.com/assets/4968224/15612648/f8877cfe-242f-11e6-9cb2-2f7a3af7311c.png)
